### PR TITLE
#33916: restrict all PolicyKit actions connected to system shutdown

### DIFF
--- a/admin_scripts/polkit_policy_shutdown.json
+++ b/admin_scripts/polkit_policy_shutdown.json
@@ -1,0 +1,12 @@
+ {
+  "name": "Desktop - Blokér for nedlukning via systempolitik",
+  "description": "Installerer en systempolitik, der forbyder, at brugeren må lukke, genstart, hvile osv. maskinen.\n\nUdarbejdet af Alexander Faithfull <af@magenta.dk>.",
+  "parameters": [
+    {
+      "name": "Aktivér?",
+      "type": "string",
+      "required": false,
+      "description": "systempolitik vil blive fjernet, hvis dette parameter er tomt eller ordet 'falsk'"
+    }
+  ]
+}

--- a/admin_scripts/polkit_policy_shutdown.sh
+++ b/admin_scripts/polkit_policy_shutdown.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+#================================================================
+# HEADER
+#================================================================
+#% SYNOPSIS
+#+    polkit_policy_shutdown.sh [ENFORCE]
+#%
+#% DESCRIPTION
+#%    This script installs a mandatory PolicyKit policy that prevents the
+#%    "user" or "lightdm" users from sleeping, hibernating, restarting or
+#%    shutting down the system.
+#%
+#%    It takes one optional parameter: whether or not to enforce this policy.
+#%    If this parameter is missing, empty, "false", or "falsk", the policy will
+#%    be removed; otherwise, it will be enforced.
+#%
+#================================================================
+#- IMPLEMENTATION
+#-    version         polkit_policy_shutdown.sh (magenta.dk) 1.0.0
+#-    author          Alexander Faithfull
+#-    copyright       Copyright 2019, 2020 Magenta ApS
+#-    license         GNU General Public License
+#-    email           af@magenta.dk
+#-
+#================================================================
+#  HISTORY
+#     2019/09/25 : af : dconf_policy_shutdown.sh created
+#     2020/01/27 : af : This script created based on dconf_policy_shutdown.sh
+#
+#================================================================
+# END_OF_HEADER
+#================================================================
+
+set -x
+
+POLICY="/etc/polkit-1/localauthority/90-mandatory.d/10-os2borgerpc-no-user-shutdown.pkla"
+
+if [ "$1" = "" -o "$1" = "false" -o "$1" = "falsk" ]; then
+    rm -f "$POLICY"
+else
+    if [ ! -d "`dirname "$POLICY"`" ]; then
+        mkdir "`dirname "$POLICY"`"
+    fi
+
+    cat > "$POLICY" <<END
+[Restrict system shutdown]
+Identity=unix-user:user;unix-user:lightdm
+Action=org.freedesktop.login1.hibernate*;org.freedesktop.login1.power-off*;org.freedesktop.login1.reboot*;org.freedesktop.login1.suspend*;org.freedesktop.login1.lock-sessions
+ResultAny=no
+ResultActive=no
+ResultInactive=no
+END
+fi
+
+# PolicyKit is supposed to monitor the /etc/polkit-1/localauthority folder, but
+# err on the side of caution and restart the service
+systemctl restart polkitd.service || systemctl restart polkit.service


### PR DESCRIPTION
This branch (with its mighty _one commit_) introduces a new script that should hopefully disable all user-accessible shutdown-related actions: suspending, hibernating, rebooting, and shutting down. (It also speculatively attempts to disable the `org.freedesktop.login1.lock-sessions` action.)

(Running this script produces a slightly nonsensical UI at first: there are "Suspend" and "Power off" buttons that don't do anything. Logging out and in again removes the options that correspond to these now-forbidden actions.)