### PR TITLE
#34339: add Google Chrome 79 support to the OS2display control script

### DIFF
--- a/admin_scripts/ubuntu/ubuntu_16.04/os2display-specific/auto_activate_chrome.py
+++ b/admin_scripts/ubuntu/ubuntu_16.04/os2display-specific/auto_activate_chrome.py
@@ -65,6 +65,8 @@ elif chrome_version == '77':
     driver_version = '77.0.3865.40'
 elif chrome_version == '78':
     driver_version = '78.0.3904.70'
+elif chrome_version == '79':
+    driver_version = '79.0.3945.36'
 else:
     print('Chrome version not supported.')
     sys.exit(1)


### PR DESCRIPTION
This has been tested on one of our test machines, and works as expected.

New machines are starting to get Google Chrome 79 installed through the `google-chrome-stable` package, so we should roll this out to production as soon as the branch has been merged.