### PR TITLE
[#39152] Added Ubuntu 20.04 support to the shutdown-blocking policy script

### DIFF
--- a/admin_scripts/polkit_policy_shutdown.sh
+++ b/admin_scripts/polkit_policy_shutdown.sh
@@ -46,7 +46,7 @@ else
     cat > "$POLICY" <<END
 [Restrict system shutdown]
 Identity=unix-user:user;unix-user:lightdm
-Action=org.freedesktop.login1.hibernate*;org.freedesktop.login1.power-off*;org.freedesktop.login1.reboot*;org.freedesktop.login1.suspend*;org.freedesktop.login1.lock-sessions
+Action=org.freedesktop.login1.hibernate*;org.freedesktop.login1.power-off*;org.freedesktop.login1.reboot*;org.freedesktop.login1.suspend*;org.freedesktop.login1.lock-sessions;org.freedesktop.login1.set-reboot*
 ResultAny=no
 ResultActive=no
 ResultInactive=no


### PR DESCRIPTION
This adds some extra filtered actions to `polkit_policy_shutdown.sh`, because `polkit` implicitly gives users with these privileges access to `org.freedesktop.login1.reboot`.

Tested on Ubuntu 20.04/OS2borgerPC, where these actions exist, and on my regular Ubuntu 18.04 installation, where they don't.