### PR TITLE
[#43754] Add an Ubuntu 20.04-friendly NumLock control script

### DIFF
--- a/admin_scripts/xdg_policy_numlock.json
+++ b/admin_scripts/xdg_policy_numlock.json
@@ -1,0 +1,12 @@
+ {
+  "name": "Desktop - Sæt NumLock-tilstand",
+  "description": "Tvinger NumLock til at være slået til eller fra under opstart.\n\nUdarbejdet af Alexander Faithfull <af@magenta.dk>.",
+  "parameters": [
+    {
+      "name": "Ønsket tilstand",
+      "type": "string",
+      "required": false,
+      "description": "'til' eller 'fra'"
+    }
+  ]
+}

--- a/admin_scripts/xdg_policy_numlock.sh
+++ b/admin_scripts/xdg_policy_numlock.sh
@@ -1,0 +1,63 @@
+#!/bin/sh
+
+#================================================================
+# HEADER
+#================================================================
+#% SYNOPSIS
+#+    xdg_policy_numlock.sh [MODE]
+#%
+#% DESCRIPTION
+#%    This script controls the state of the NumLock key when the user logs in.
+#%
+#%    It takes one optional parameter: the state to set the NumLock key to.
+#%    This should be either "on" (or, equivalently, "til") or "off" (or,
+#%    equivalently, "fra"). If this parameter is missing, empty, "false", or
+#%    "falsk", the policy will instead be removed.
+#%
+#================================================================
+#- IMPLEMENTATION
+#-    version         pulse_policy_profile.sh (magenta.dk) 1.0.0
+#-    author          Alexander Faithfull
+#-    copyright       Copyright 2020 Magenta ApS
+#-    license         GNU General Public License
+#-    email           af@magenta.dk
+#-
+#================================================================
+#  HISTORY
+#     2021/05/27 : af : Script created
+#
+#================================================================
+# END_OF_HEADER
+#================================================================
+
+POLICY="/etc/xdg/autostart/os2borgerpc-numlock.desktop"
+
+set -ex
+
+if [ "$1" = "" -o "$1" = "false" -o "$1" = "falsk" ]; then
+    rm -f "$POLICY"
+else
+    if [ ! -f "/usr/bin/numlockx" ]; then
+        # Stop Debconf from doing anything
+        export DEBIAN_FRONTEND=noninteractive
+        apt-get update > /dev/null
+        apt-get -yf install numlockx
+    fi
+
+    if [ "$1" = "on" -o "$1" = "til" ]; then
+        state="on"
+    elif [ "$1" = "off" -o "$1" = "fra" ]; then
+        state="off"
+    else
+        exit 2
+    fi
+    cat > "$POLICY" <<END
+[Desktop Entry]
+Type=Application
+Name=OS2borgerPC - Set NumLock state
+Name[da]=OS2borgerPC - Sæt NumLock-tilstand
+Exec=/usr/bin/numlockx $state
+Terminal=False
+NoDisplay=true
+END
+fi


### PR DESCRIPTION
This PR adds a script that configures a system-wide [XDG autostart application](https://specifications.freedesktop.org/autostart-spec/0.5/ar01s02.html) to switch the `NumLock` state either on or off when users log in. (It can also unregister this application, if you call it with the parameter `false`.)

If you'd like to test this script, it's presently a local script on our site with the name `(af) Desktop - Sæt NumLock-tilstand`.