### PR TITLE
Test: Remove explicit locale setting from isolinux.cfg

### DIFF
--- a/image/clonezilla-overwrites/boot/grub/grub.cfg
+++ b/image/clonezilla-overwrites/boot/grub/grub.cfg
@@ -33,7 +33,7 @@ play 960 440 1 0 4 440 1
 
 menuentry "Installer OS2borgerPC fra dette medium"{
   search --set -f /live/vmlinuz
-  linux /live/vmlinuz boot=live union=overlay username=user config components quiet noswap nolocales edd=on nomodeset ocs_live_run="/bin/bash /lib/live/mount/medium/os2borgerpc/install-local.sh" ocs_live_extra_param="" keyboard-layouts=dk ocs_live_batch="no" locales="en_US.UTF-8" vga=791 ip=frommedia net.ifnames=0  splash i915.blacklist=yes radeonhd.blacklist=yes nouveau.blacklist=yes vmwgfx.enable_fbdev=1
+  linux /live/vmlinuz boot=live union=overlay username=user config components quiet noswap nolocales edd=on nomodeset ocs_live_run="/bin/bash /lib/live/mount/medium/os2borgerpc/install-local.sh" ocs_live_extra_param="" keyboard-layouts=dk ocs_live_batch="no" vga=791 ip=frommedia net.ifnames=0  splash i915.blacklist=yes radeonhd.blacklist=yes nouveau.blacklist=yes vmwgfx.enable_fbdev=1
   initrd /live/initrd.img
 }
 

--- a/image/clonezilla-overwrites/syslinux/isolinux.cfg
+++ b/image/clonezilla-overwrites/syslinux/isolinux.cfg
@@ -33,7 +33,7 @@ label OS2borgerPC
   MENU LABEL Installer OS2borgerPC fra dette medium
   # MENU PASSWD
   kernel /live/vmlinuz
-append initrd=/live/initrd.img boot=live union=overlay username=user config components quiet noswap nolocales edd=on nomodeset ocs_live_run="/bin/bash /lib/live/mount/medium/os2borgerpc/install-local.sh" ocs_live_extra_param="" keyboard-layouts=dk ocs_live_batch="no" locales="en_US.UTF-8" vga=791 ip=frommedia net.ifnames=0  splash i915.blacklist=yes radeonhd.blacklist=yes nouveau.blacklist=yes vmwgfx.enable_fbdev=1
+append initrd=/live/initrd.img boot=live union=overlay username=user config components quiet noswap nolocales edd=on nomodeset ocs_live_run="/bin/bash /lib/live/mount/medium/os2borgerpc/install-local.sh" ocs_live_extra_param="" keyboard-layouts=dk ocs_live_batch="no" vga=791 ip=frommedia net.ifnames=0  splash i915.blacklist=yes radeonhd.blacklist=yes nouveau.blacklist=yes vmwgfx.enable_fbdev=1
   TEXT HELP
   ENDTEXT
 

--- a/image/clonezilla-overwrites/syslinux/syslinux.cfg
+++ b/image/clonezilla-overwrites/syslinux/syslinux.cfg
@@ -33,7 +33,7 @@ label OS2borgerPC
   MENU LABEL Installer OS2borgerPC fra dette medium
   # MENU PASSWD
   kernel /live/vmlinuz
-append initrd=/live/initrd.img boot=live union=overlay username=user config components quiet noswap nolocales edd=on nomodeset ocs_live_run="/bin/bash /lib/live/mount/medium/os2borgerpc/install-local.sh" ocs_live_extra_param="" keyboard-layouts=dk ocs_live_batch="no" locales="en_US.UTF-8" vga=791 ip=frommedia net.ifnames=0  splash i915.blacklist=yes radeonhd.blacklist=yes nouveau.blacklist=yes vmwgfx.enable_fbdev=1
+append initrd=/live/initrd.img boot=live union=overlay username=user config components quiet noswap nolocales edd=on nomodeset ocs_live_run="/bin/bash /lib/live/mount/medium/os2borgerpc/install-local.sh" ocs_live_extra_param="" keyboard-layouts=dk ocs_live_batch="no" vga=791 ip=frommedia net.ifnames=0  splash i915.blacklist=yes radeonhd.blacklist=yes nouveau.blacklist=yes vmwgfx.enable_fbdev=1
   TEXT HELP
   ENDTEXT
 


### PR DESCRIPTION
Next time we build an image I suggest trying this out to clean up non breaking errors (and their error messages) during the installation